### PR TITLE
Fix ACP Tabler selection, remember-me login, and MySQL 8 upgrades.

### DIFF
--- a/src/admin/admins.php
+++ b/src/admin/admins.php
@@ -103,7 +103,8 @@ if($_REQUEST['action'] == 'account')
 		else
 		{
 			$newPW = PasswordHashSetAdminPassword((int)$adminRow['adminid'], $_POST['newpw1']);
-			$_SESSION['bm_adminAuth'] = AdminSessionAuthBind($newPW, (int)$adminRow['adminid']);
+			if($newPW !== false)
+				$_SESSION['bm_adminAuth'] = AdminSessionAuthBind($newPW, (int)$adminRow['adminid']);
 		}
 	}
 
@@ -179,7 +180,13 @@ if($_REQUEST['action'] == 'account')
 				if($_POST['newpw1'] != '')
 				{
 					$pw = PasswordHashSetAdminPassword((int)$admin['adminid'], $_POST['newpw1']);
-					$salt = '';
+					if($pw === false)
+					{
+						$pw = $admin['password'];
+						$salt = $admin['password_salt'];
+					}
+					else
+						$salt = '';
 				}
 				else
 				{

--- a/src/admin/index.php
+++ b/src/admin/index.php
@@ -108,26 +108,16 @@ if(isset($_REQUEST['action']) && $_REQUEST['action']=='login')
 						$adminUserRow['last_try'] = 0;
 						$db->Query('UPDATE {pre}admins SET `last_try`=0 WHERE `adminid`=?', $adminUserRow['adminid']);
 					}
-					$md5saltlogin=0;
-					if(hash_equals((string)$adminUserRow['password'], md5($pw.$adminUserRow['password_salt']))) { // Update old passwords
-						$newPW = PasswordHashCreate($pw, 'admin');
-						$db->Query('UPDATE {pre}admins SET `password`=?,`password_salt`=? WHERE `adminid`=?', 
-							$newPW, '', $adminUserRow['adminid']); // try update
-						$res = $db->Query('SELECT `adminid`,`username`,`password`,`password_salt`,`last_try` FROM {pre}admins WHERE `username`=?',
-						$username); // check length
-						$lengthrow = $res->FetchArray(MYSQLI_ASSOC);
-						if($newPW != $lengthrow['password']) { // make rollback
-							$db->Query('UPDATE {pre}admins SET `password`=?,`password_salt`=? WHERE `adminid`=?', 
-							$adminUserRow['password'], $adminUserRow['password_salt'], $adminUserRow['adminid']);
-							$md5saltlogin=1;
-						}
-						else {
-							$adminUserRow['password'] = $newPW;
-						}
-					}
-					if(password_verify($pw, $adminUserRow['password']) || $md5saltlogin==1)
+					$legacyOk = hash_equals((string)$adminUserRow['password'], md5($pw.$adminUserRow['password_salt']));
+					$modernOk = PasswordHashIsModern($adminUserRow['password']) && password_verify($pw, $adminUserRow['password']);
+					if($legacyOk || $modernOk)
 					{
-						$upgradedHash = PasswordHashUpgradeAdmin((int)$adminUserRow['adminid'], $pw, $adminUserRow['password']);
+						$upgradedHash = PasswordHashUpgradeAdmin(
+							(int)$adminUserRow['adminid'],
+							$pw,
+							$adminUserRow['password'],
+							isset($adminUserRow['password_salt']) ? $adminUserRow['password_salt'] : ''
+						);
 						if($upgradedHash !== false)
 							$adminUserRow['password'] = $upgradedHash;
 

--- a/src/admin/templates/prefs.templates.tpl
+++ b/src/admin/templates/prefs.templates.tpl
@@ -36,7 +36,7 @@
 		<div class="mb-3 row">
 			<label class="col-sm-2 col-form-label">{lng p="template"}</label>
 			<div class="col-sm-10">
-				<select name="template" class="form-select"
+				<select name="template" class="form-select">
 				{foreach from=$templates item=templateInfo key=template}
 					<option value="{$template}"{if $defaultTemplate==$template} selected="selected"{/if}>{text value=$templateInfo.title}</option>
 				{/foreach}

--- a/src/index.php
+++ b/src/index.php
@@ -1498,8 +1498,12 @@ else
 			$remember = BMUser::ValidateRememberMe($_COOKIE['bm_savedToken']);
 			if($remember !== false)
 			{
+				$trusted = BMMfa::RememberMeMaySkipVerify(
+					(int)$remember['userID'],
+					isset($remember['expires']) ? (int)$remember['expires'] : 0
+				);
 				ob_start();
-				list($result, $param) = BMUser::LoginByUserID($remember['userID'], true, true);
+				list($result, $param) = BMUser::LoginByUserID($remember['userID'], true, true, false, $trusted);
 				ob_end_clean();
 			}
 			else
@@ -1839,5 +1843,7 @@ if(!SessionAssignLoginPageActive('user'))
 		$tpl->assign('welcomeBack', FALSE);
 	}
 }
+
+$tpl->assign('savelogin', isset($_POST['savelogin']));
 
 $tpl->display('nli/index.tpl');

--- a/src/prefs.php
+++ b/src/prefs.php
@@ -1628,10 +1628,8 @@ else if($_REQUEST['action'] == 'membership')
 				$thisUser->UpdateContactData($userRow, false, true, 0, $suPass1);
 				$db->Query('UPDATE {pre}users SET passwort_salt=? WHERE id=?', '', (int)$userRow['id']);
 				BMUser::InvalidateOtherSessionsForUser((int)$userRow['id']);
+				BMUser::InvalidateRememberMeForUser((int)$userRow['id']);
 
-				// delete cookies
-				if(isset($_COOKIE['bm_savedToken']))
-					BMUser::DeleteSavedLogin($_COOKIE['bm_savedToken']);
 				BMSecureSetCookie('bm_savedUser', '', time() - TIME_ONE_HOUR);
 				BMSecureSetCookie('bm_savedToken', '', time() - TIME_ONE_HOUR);
 				BMSecureSetCookie('bm_savedPassword', '', time() - TIME_ONE_HOUR);

--- a/src/serverlib/common.inc.php
+++ b/src/serverlib/common.inc.php
@@ -1264,6 +1264,31 @@ function GenerateRandomSalt($length = 8)
 }
 
 /**
+ * MySQL 8 dropped integer display widths (`int(11)` → `int`). Treat them as equal
+ * so structure sync does not loop on ALTER TABLE MODIFY.
+ *
+ * @param string $type
+ * @return string
+ */
+function BMDbNormalizeFieldType($type)
+{
+	$type = strtolower(trim((string)$type));
+	$type = preg_replace('/\binteger\b/', 'int', $type);
+	$type = preg_replace('/\b(tinyint|smallint|mediumint|int|bigint|year)\(\d+\)/', '$1', $type);
+	return $type;
+}
+
+/**
+ * @param string $actual
+ * @param string $expected
+ * @return bool
+ */
+function BMDbFieldTypeMatches($actual, $expected)
+{
+	return BMDbNormalizeFieldType($actual) === BMDbNormalizeFieldType($expected);
+}
+
+/**
  * synchronize DB structure against an DB structure array
  *
  * @param array $databaseStructure (New/correct) DB structure
@@ -1277,7 +1302,7 @@ function SyncDBStruct($databaseStructure)
 	$syncQueries = array();
 
 	// get tables
-	$defaultTables = array();
+	$myTables = array();
 	$res = $db->Query('SHOW TABLES');
 	while($row = $res->FetchArray(MYSQLI_NUM))
 		$myTables[] = $row[0];
@@ -1326,7 +1351,7 @@ function SyncDBStruct($databaseStructure)
 				else
 				{
 					$myField = $myFields[$field[0]];
-					if($myField[1] != $field[1]
+					if(!BMDbFieldTypeMatches($myField[1], $field[1])
 						|| $myField[2] != $field[2]
 						|| ($myField[4] != $field[4] && !(($myField[4]==0 && $field[4]=='') || ($myField[4]=='' && $field[4]==0)))
 						|| (isset($field[5]) && $myField[5] != $field[5]))
@@ -3507,18 +3532,33 @@ function GetAvailableTemplates()
 	if(is_object($dir))
 	{
 		while($file = $dir->read())
-			if($file != '.'
-				&& $file != '..'
-				&& is_dir(B1GMAIL_DIR . 'templates/' . $file)
-				&& file_exists(B1GMAIL_DIR . 'templates/' . $file . '/cache/')
-				&& file_exists(B1GMAIL_DIR . 'templates/' . $file . '/info.php'))
 		{
+			if($file == '.' || $file == '..')
+				continue;
+
+			$tplDir = B1GMAIL_DIR . 'templates/' . $file;
+			if(!is_dir($tplDir) || !file_exists($tplDir . '/info.php'))
+				continue;
+
+			$cacheDir = $tplDir . '/cache';
+			if(!is_dir($cacheDir))
+			{
+				@mkdir($cacheDir, 0777);
+				@chmod($cacheDir, 0777);
+			}
+			if(!is_dir($cacheDir))
+				continue;
+
 			$info = GetTemplateInfo($file);
+			if(!is_array($info) || !isset($info['title']))
+				continue;
+
 			$result[$file] = $info;
 		}
 		$dir->close();
 	}
 
+	ksort($result, SORT_STRING);
 	return($result);
 }
 

--- a/src/serverlib/mfa.inc.php
+++ b/src/serverlib/mfa.inc.php
@@ -939,6 +939,7 @@ class BMMfa
 				time(),
 				(int)$mfaAccountID);
 		}
+		self::InvalidateRememberMeForMfaAccount($mfaAccountID);
 	}
 
 	/**
@@ -1109,6 +1110,49 @@ class BMMfa
 			BMUser::InvalidateRememberMeForUser($accountID);
 
 		return true;
+	}
+
+	/**
+	 * Remember-me cookie may skip login MFA when it was issued after MFA
+	 * was enabled on this account (trusted device).
+	 *
+	 * @param int $userID
+	 * @param int $tokenExpires
+	 * @return bool
+	 */
+	public static function RememberMeMaySkipVerify($userID, $tokenExpires)
+	{
+		$account = self::GetAccount('user', (int)$userID);
+		if(!self::RequiresMfaVerifyAtLogin($account))
+			return true;
+
+		$enabledAt = self::GetEnabledAtTimestamp($account);
+		if($enabledAt <= 0)
+			return true;
+
+		$issuedAt = (int)$tokenExpires - TIME_ONE_YEAR;
+		return $issuedAt + 300 >= $enabledAt;
+	}
+
+	/**
+	 * @param int $mfaAccountID
+	 */
+	public static function InvalidateRememberMeForMfaAccount($mfaAccountID)
+	{
+		global $db;
+
+		$res = $db->Query('SELECT account_type,account_id FROM {pre}mfa_accounts WHERE id=?',
+			(int)$mfaAccountID);
+		if($res->RowCount() != 1)
+		{
+			$res->Free();
+			return;
+		}
+		$row = $res->FetchArray(MYSQLI_ASSOC);
+		$res->Free();
+
+		if($row['account_type'] === 'user')
+			BMUser::InvalidateRememberMeForUser((int)$row['account_id']);
 	}
 
 	/**
@@ -1437,6 +1481,8 @@ class BMMfa
 			'group_id'       => $groupID,
 			'password_plain' => $passwordPlain,
 			'recovery'       => $account['recovery_mode'] === 'altmail',
+			'savelogin'      => isset($_POST['savelogin']),
+			'ssl'            => isset($_POST['ssl']) || (!empty($_COOKIE['bm_savedSSL']) && $_COOKIE['bm_savedSSL'] === '1'),
 		);
 
 		self::BeginPending('user', $userID, $meta);
@@ -1527,6 +1573,22 @@ class BMMfa
 
 		self::ClearPending();
 		unset($pending['meta']['password_plain']);
+
+		if(!empty($pending['meta']['savelogin']))
+		{
+			if(isset($_COOKIE['bm_savedToken']))
+				BMUser::DeleteSavedLogin($_COOKIE['bm_savedToken']);
+
+			$cookieToken = BMUser::SaveLogin($userID);
+			BMSecureSetCookie('bm_savedUser', $row['email'], time() + TIME_ONE_YEAR);
+			if(isset($_COOKIE['savedPassword']))
+				BMSecureSetCookie('bm_savedPassword', '', time() - TIME_ONE_HOUR);
+			if($cookieToken !== false)
+				BMSecureSetCookie('bm_savedToken', $cookieToken, time() + TIME_ONE_YEAR);
+			BMSecureSetCookie('bm_savedSSL',
+				!empty($pending['meta']['ssl']) ? '1' : '0',
+				time() + TIME_ONE_YEAR);
+		}
 
 		$groupID = (int)$row['gruppe'];
 		self::ClearStaleSetupRequired('user', $userID);
@@ -1736,6 +1798,7 @@ class BMMfa
 			'yes',
 			time(),
 			(int)$mfaAccountID);
+		self::InvalidateRememberMeForMfaAccount($mfaAccountID);
 		self::SetSetupRequiredSession(false);
 	}
 

--- a/src/serverlib/passwordhash.inc.php
+++ b/src/serverlib/passwordhash.inc.php
@@ -178,15 +178,96 @@ function PasswordHashNeedsUpgrade($hash, $context = 'li')
 }
 
 /**
- * @param int    $userID
- * @param string $passwordPlain
- * @param array  $row
- * @return void
+ * Maximum characters the password column can store (0 = unknown).
+ *
+ * @param string $table
+ * @param string $column
+ * @return int
  */
-function PasswordHashUpgradeUser($userID, $passwordPlain, $row)
+function PasswordHashColumnMaxLength($table, $column)
 {
 	global $db;
 
+	static $cache = array();
+	$key = $table . '.' . $column;
+	if(isset($cache[$key]))
+		return $cache[$key];
+
+	$res = $db->Query('SHOW COLUMNS FROM {pre}' . $table . ' LIKE ?', $column);
+	$col = $res->FetchArray(MYSQLI_ASSOC);
+	$res->Free();
+	if(!is_array($col) || empty($col['Type']))
+		return $cache[$key] = 0;
+
+	$type = strtolower((string)$col['Type']);
+	if(preg_match('/^(?:var)?char\((\d+)\)/', $type, $m))
+		return $cache[$key] = (int)$m[1];
+	if(strpos($type, 'text') !== false || strpos($type, 'blob') !== false)
+		return $cache[$key] = PHP_INT_MAX;
+
+	return $cache[$key] = 0;
+}
+
+/**
+ * @param string $table
+ * @param string $column
+ * @param string $hash
+ * @return bool
+ */
+function PasswordHashCanStoreInColumn($table, $column, $hash)
+{
+	$max = PasswordHashColumnMaxLength($table, $column);
+	if($max <= 0)
+		return true;
+
+	return strlen((string)$hash) <= $max;
+}
+
+/**
+ * @param string      $table
+ * @param string      $idColumn
+ * @param int         $id
+ * @param string      $hashColumn
+ * @param string      $saltColumn
+ * @param string      $newHash
+ * @param string      $oldHash
+ * @param string|null $oldSalt
+ * @return bool
+ */
+function PasswordHashWriteAndVerify($table, $idColumn, $id, $hashColumn, $saltColumn, $newHash, $oldHash, $oldSalt)
+{
+	global $db;
+
+	$id = (int)$id;
+	if($id <= 0 || !is_string($newHash) || $newHash === '')
+		return false;
+
+	if(!PasswordHashCanStoreInColumn($table, $hashColumn, $newHash))
+		return false;
+
+	$db->Query('UPDATE {pre}'.$table.' SET `'.$hashColumn.'`=?,`'.$saltColumn.'`=? WHERE `'.$idColumn.'`=?',
+		$newHash,
+		'',
+		$id);
+
+	$res = $db->Query('SELECT `'.$hashColumn.'` FROM {pre}'.$table.' WHERE `'.$idColumn.'`=?', $id);
+	$row = $res->FetchArray(MYSQLI_ASSOC);
+	$res->Free();
+
+	if(!is_array($row) || !hash_equals($newHash, (string)$row[$hashColumn]))
+	{
+		$db->Query('UPDATE {pre}'.$table.' SET `'.$hashColumn.'`=?,`'.$saltColumn.'`=? WHERE `'.$idColumn.'`=?',
+			$oldHash,
+			$oldSalt,
+			$id);
+		return false;
+	}
+
+	return true;
+}
+
+function PasswordHashUpgradeUser($userID, $passwordPlain, $row)
+{
 	if(!is_array($row) || !isset($row['passwort']))
 		return;
 
@@ -195,11 +276,11 @@ function PasswordHashUpgradeUser($userID, $passwordPlain, $row)
 
 	$passwordPlain = CharsetDecode($passwordPlain, false, 'ISO-8859-15');
 	$newHash = PasswordHashCreate($passwordPlain, 'li');
+	$oldSalt = isset($row['passwort_salt']) ? $row['passwort_salt'] : '';
 
-	$db->Query('UPDATE {pre}users SET passwort=?, passwort_salt=? WHERE id=?',
-		$newHash,
-		'',
-		(int)$userID);
+	if(!PasswordHashWriteAndVerify('users', 'id', $userID, 'passwort', 'passwort_salt', $newHash, $row['passwort'], $oldSalt))
+		return;
+
 	if(function_exists('ClientApiRememberPassword'))
 		ClientApiRememberPassword((int)$userID, $passwordPlain);
 }
@@ -208,20 +289,17 @@ function PasswordHashUpgradeUser($userID, $passwordPlain, $row)
  * @param int    $adminID
  * @param string $passwordPlain
  * @param string $currentHash
- * @return string|false New hash or false if unchanged
+ * @param string $currentSalt
+ * @return string|false New hash or false if unchanged / not stored
  */
-function PasswordHashUpgradeAdmin($adminID, $passwordPlain, $currentHash)
+function PasswordHashUpgradeAdmin($adminID, $passwordPlain, $currentHash, $currentSalt = '')
 {
-	global $db;
-
 	if(!PasswordHashNeedsUpgrade($currentHash, 'admin'))
 		return false;
 
 	$newHash = PasswordHashCreate($passwordPlain, 'admin');
-	$db->Query('UPDATE {pre}admins SET `password`=?,`password_salt`=? WHERE `adminid`=?',
-		$newHash,
-		'',
-		(int)$adminID);
+	if(!PasswordHashWriteAndVerify('admins', 'adminid', $adminID, 'password', 'password_salt', $newHash, $currentHash, $currentSalt))
+		return false;
 
 	return $newHash;
 }
@@ -237,11 +315,21 @@ function PasswordHashSetUserPassword($userID, $passwordPlain)
 
 	$passwordPlain = CharsetDecode($passwordPlain, false, 'ISO-8859-15');
 	$newHash = PasswordHashCreate($passwordPlain, 'li');
+	$oldHash = '';
+	$oldSalt = '';
 
-	$db->Query('UPDATE {pre}users SET passwort=?, passwort_salt=? WHERE id=?',
-		$newHash,
-		'',
-		(int)$userID);
+	$res = $db->Query('SELECT passwort,passwort_salt FROM {pre}users WHERE id=?', (int)$userID);
+	if($res->RowCount() == 1)
+	{
+		$row = $res->FetchArray(MYSQLI_ASSOC);
+		$oldHash = $row['passwort'];
+		$oldSalt = $row['passwort_salt'];
+	}
+	$res->Free();
+
+	if(!PasswordHashWriteAndVerify('users', 'id', $userID, 'passwort', 'passwort_salt', $newHash, $oldHash, $oldSalt))
+		return;
+
 	if(function_exists('ClientApiRememberPassword'))
 		ClientApiRememberPassword((int)$userID, $passwordPlain);
 }
@@ -249,17 +337,27 @@ function PasswordHashSetUserPassword($userID, $passwordPlain)
 /**
  * @param int    $adminID
  * @param string $passwordPlain
- * @return string
+ * @return string|false
  */
 function PasswordHashSetAdminPassword($adminID, $passwordPlain)
 {
 	global $db;
 
 	$newHash = PasswordHashCreate($passwordPlain, 'admin');
-	$db->Query('UPDATE {pre}admins SET `password`=?,`password_salt`=? WHERE `adminid`=?',
-		$newHash,
-		'',
-		(int)$adminID);
+	$oldHash = '';
+	$oldSalt = '';
+
+	$res = $db->Query('SELECT `password`,`password_salt` FROM {pre}admins WHERE `adminid`=?', (int)$adminID);
+	if($res->RowCount() == 1)
+	{
+		$row = $res->FetchArray(MYSQLI_ASSOC);
+		$oldHash = $row['password'];
+		$oldSalt = $row['password_salt'];
+	}
+	$res->Free();
+
+	if(!PasswordHashWriteAndVerify('admins', 'adminid', $adminID, 'password', 'password_salt', $newHash, $oldHash, $oldSalt))
+		return false;
 
 	return $newHash;
 }

--- a/src/serverlib/user.class.php
+++ b/src/serverlib/user.class.php
@@ -1641,9 +1641,11 @@ class BMUser
 	 * @param int  $userID
 	 * @param bool $createSession
 	 * @param bool $successLog
+	 * @param bool $adminImpersonate
+	 * @param bool $rememberMeTrusted Skip login MFA (trusted device cookie)
 	 * @return array
 	 */
-	public static function LoginByUserID($userID, $createSession = true, $successLog = true, $adminImpersonate = false)
+	public static function LoginByUserID($userID, $createSession = true, $successLog = true, $adminImpersonate = false, $rememberMeTrusted = false)
 	{
 		global $db, $currentCharset, $currentLanguage, $bm_prefs;
 
@@ -1684,7 +1686,7 @@ class BMUser
 		$mfaDeferred = false;
 		if($createSession)
 		{
-			if(!$adminImpersonate && BMMfa::DeferUserLoginForMfa($userID, $row, ''))
+			if(!$adminImpersonate && !$rememberMeTrusted && BMMfa::DeferUserLoginForMfa($userID, $row, ''))
 				$mfaDeferred = true;
 			else
 			{
@@ -4130,7 +4132,10 @@ class BMUser
 		if($userID <= 0 || !password_verify($secret, $hash))
 			return(false);
 
-		return(array('userID' => $userID));
+		return(array(
+			'userID'  => $userID,
+			'expires' => (int)$row['expires'],
+		));
 	}
 
 	/**

--- a/src/setup/common.inc.php
+++ b/src/setup/common.inc.php
@@ -1047,12 +1047,36 @@ function GeneratePW($length = 16)
 
 
 /**
+ * MySQL 8 dropped integer display widths (`int(11)` → `int`).
+ *
+ * @param string $type
+ * @return string
+ */
+function BMDbNormalizeFieldType($type)
+{
+	$type = strtolower(trim((string)$type));
+	$type = preg_replace('/\binteger\b/', 'int', $type);
+	$type = preg_replace('/\b(tinyint|smallint|mediumint|int|bigint|year)\(\d+\)/', '$1', $type);
+	return $type;
+}
+
+/**
+ * @param string $actual
+ * @param string $expected
+ * @return bool
+ */
+function BMDbFieldTypeMatches($actual, $expected)
+{
+	return BMDbNormalizeFieldType($actual) === BMDbNormalizeFieldType($expected);
+}
+
+/**
  * synchronize DB structure against an DB structure array
  *
  * @param resource $connection
  * @param array $databaseStructure (New/correct) DB structure
  * @param bool $return Return queries?
- * @param bool $return Return queries?
+ * @param bool $utf8Mode
  * @return array
  */
 function SyncDBStruct($connection, $databaseStructure, $return = true, $utf8Mode = false)
@@ -1110,7 +1134,7 @@ function SyncDBStruct($connection, $databaseStructure, $return = true, $utf8Mode
 				else
 				{
 					$myField = $myFields[$field[0]];
-					if($myField[1] != $field[1]
+					if(!BMDbFieldTypeMatches($myField[1], $field[1])
 						|| $myField[2] != $field[2]
 						|| ($myField[4] != $field[4] && !(($myField[4]==0 && $field[4]=='') || ($myField[4]=='' && $field[4]==0)))
 						|| $myField[5] != $field[5])

--- a/src/templates/modern/nli/index.tpl
+++ b/src/templates/modern/nli/index.tpl
@@ -76,6 +76,7 @@
 							{if $welcomeBack}
 							<input type="hidden" name="email_full" value="{$smarty.cookies.bm_savedUser}" />
 							<input type="hidden" name="password" value="" />
+							<input type="hidden" name="savelogin" value="true" />
 							{if $smarty.cookies.bm_savedSSL}<input type="hidden" name="ssl" value="true" />{/if}
 
 							<div class="btn-group">
@@ -177,6 +178,12 @@
 				<label class="sr-only" for="password_p">{lng p="password"}</label>
 				<input type="password" name="password" id="password_p" class="form-control" placeholder="{lng p="password"}" required="true" />
 			</div>
+		</div>
+		<div class="checkbox">
+			<label>
+				<input type="checkbox" name="savelogin" id="savelogin_p"{if $savelogin} checked="checked"{/if} />
+				{lng p="savelogin"}
+			</label>
 		</div>
 		{if $ssl_login_option}<div class="checkbox">
 			<label>

--- a/src/templates/modern/nli/login.smsvalidation.tpl
+++ b/src/templates/modern/nli/login.smsvalidation.tpl
@@ -2,6 +2,7 @@
 	{csrffield}
 <input type="hidden" name="do" value="login" />
 <input type="hidden" name="email_full" value="{if isset($email)}{text value=$email}{/if}" />
+{if $savelogin}<input type="hidden" name="savelogin" value="true" />{/if}
 
 	<div class="container">
 		<div class="page-header"><h1>{lng p="smsvalidation"}</h1></div>

--- a/src/templates/modern/nli/login.tpl
+++ b/src/templates/modern/nli/login.tpl
@@ -41,6 +41,12 @@
 							<input type="password" name="password" id="password" class="form-control" placeholder="{lng p="password"}" required="true" />
 						</div>
 					</div>
+					<div class="checkbox">
+						<label>
+							<input type="checkbox" name="savelogin" id="savelogin"{if $savelogin} checked="checked"{/if} />
+							{lng p="savelogin"}
+						</label>
+					</div>
 					{if $ssl_login_option}<div class="checkbox">
 						<label>
 							<input type="checkbox" id="ssl"{if $ssl_login_enable} checked="checked"{/if} onchange="updateFormSSL(this)" onclick="updateFormSSL(this)" />

--- a/src/templates/tabler/nli/index.tpl
+++ b/src/templates/tabler/nli/index.tpl
@@ -101,6 +101,7 @@
 							{if $welcomeBack}
 							<input type="hidden" name="email_full" value="{$smarty.cookies.bm_savedUser}" />
 							<input type="hidden" name="password" value="" />
+							<input type="hidden" name="savelogin" value="1" />
 							{if $smarty.cookies.bm_savedSSL}<input type="hidden" name="ssl" value="true" />{/if}
 
 							<div class="btn-group">
@@ -148,6 +149,10 @@
 												<input type="password" name="password" id="password_p" class="form-control" placeholder="{lng p="password"}" required="true" />
 											</div>
 										</div>
+										<label class="form-check mb-3">
+											<input type="checkbox" class="form-check-input" name="savelogin" id="savelogin_p" value="1"{if $savelogin} checked="checked"{/if} />
+											<span class="form-check-label">{lng p="savelogin"}</span>
+										</label>
 										{if $ssl_login_option}
 										<label class="form-check mb-3">
 											<input type="checkbox" class="form-check-input" id="ssl_p"{if $ssl_login_enable} checked="checked"{/if} onchange="updateFormSSL(this)" onclick="updateFormSSL(this)" />

--- a/src/templates/tabler/nli/login.form.tpl
+++ b/src/templates/tabler/nli/login.form.tpl
@@ -45,6 +45,12 @@
 		</div>
 	</div>
 
+	<div class="mb-3">
+		<label class="form-check">
+			<input type="checkbox" class="form-check-input" name="savelogin" id="savelogin" value="1"{if $savelogin} checked="checked"{/if} />
+			<span class="form-check-label">{lng p="savelogin"}</span>
+		</label>
+	</div>
 	{if $ssl_login_option}
 	<div class="mb-3">
 		<label class="form-check">

--- a/src/templates/tabler/nli/login.smsvalidation.tpl
+++ b/src/templates/tabler/nli/login.smsvalidation.tpl
@@ -2,6 +2,7 @@
 	{csrffield}
 <input type="hidden" name="do" value="login" />
 <input type="hidden" name="email_full" value="{if isset($email)}{text value=$email}{/if}" />
+{if $savelogin}<input type="hidden" name="savelogin" value="1" />{/if}
 
 {include file="nli/page.open.tpl"}
 <h1 class="mb-3">{lng p="smsvalidation"}</h1>

--- a/src/templates/tabler/nli/login.welcomeback.tpl
+++ b/src/templates/tabler/nli/login.welcomeback.tpl
@@ -11,6 +11,7 @@
 	{csrffield}
 	<input type="hidden" name="email_full" value="{$smarty.cookies.bm_savedUser}" />
 	<input type="hidden" name="password" value="" />
+	<input type="hidden" name="savelogin" value="1" />
 	{if $smarty.cookies.bm_savedSSL}<input type="hidden" name="ssl" value="true" />{/if}
 	<div class="form-footer">
 		<button type="submit" class="btn btn-primary w-100">


### PR DESCRIPTION
Keep Tabler selectable in the admin template dropdown, restore Login merken without repeating MFA on a trusted device, and refuse truncated password hashes when the column was never widened.